### PR TITLE
Add minimal Laravel skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+APP_NAME=Laravel
+APP_ENV=local
+APP_KEY=
+APP_DEBUG=true
+APP_URL=http://localhost
+
+LOG_CHANNEL=stack
+
+DB_CONNECTION=sqlite
+DB_DATABASE=database/database.sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+/vendor/
+/node_modules/
+.env
+.phpunit.result.cache
+/storage/
+/public/storage
+.idea/
+.DS_Store

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+
+class Kernel extends ConsoleKernel
+{
+    protected function schedule(Schedule $schedule): void
+    {
+        // Define your scheduled tasks
+    }
+
+    protected function commands(): void
+    {
+        $this->load(__DIR__.'/Commands');
+    }
+}

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Exceptions;
+
+use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Throwable;
+
+class Handler extends ExceptionHandler
+{
+    protected $levels = [
+        // exception levels
+    ];
+
+    public function register(): void
+    {
+        $this->reportable(function (Throwable $e) {
+            //
+        });
+    }
+}

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller as BaseController;
+
+class Controller extends BaseController
+{
+    use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http;
+
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+class Kernel extends HttpKernel
+{
+    protected $middleware = [
+        // global HTTP middleware
+    ];
+
+    protected $middlewareGroups = [
+        'web' => [
+            // web middleware
+        ],
+
+        'api' => [
+            'throttle:api',
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
+    ];
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        //
+    }
+
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        Route::middleware('web')
+            ->group(base_path('routes/web.php'));
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'name' => env('APP_NAME', 'Laravel'),
+    'env' => env('APP_ENV', 'production'),
+    'debug' => (bool) env('APP_DEBUG', false),
+    'url' => env('APP_URL', 'http://localhost'),
+];

--- a/config/database.php
+++ b/config/database.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'default' => env('DB_CONNECTION', 'sqlite'),
+
+    'connections' => [
+        'sqlite' => [
+            'driver' => 'sqlite',
+            'database' => env('DB_DATABASE', database_path('database.sqlite')),
+            'prefix' => '',
+        ],
+    ],
+];

--- a/config/view.php
+++ b/config/view.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'paths' => [resource_path('views')],
+    'compiled' => realpath(storage_path('framework/views')),
+];

--- a/database/migrations/2023_01_01_000000_create_users_table.php
+++ b/database/migrations/2023_01_01_000000_create_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class DatabaseSeeder extends Seeder
+{
+    public function run(): void
+    {
+        // Seed database
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         colors="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Welcome</title>
+</head>
+<body>
+    <h1>Hello from Laravel</h1>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/', function () {
+    return view('welcome');
+});


### PR DESCRIPTION
## Summary
- scaffold minimal Laravel-like structure
- add example route and view
- set up config, migrations, seeders, and environment example
- provide PHP Unit config and gitignore

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686b0b1cb4648323a729fa298ee27006

## Summary by Sourcery

Scaffold a minimal Laravel-like application skeleton with basic routing, views, configuration, migrations, and testing setup.

New Features:
- Scaffold core Laravel structure including HTTP and Console Kernels, service providers, controllers, and exception handler.
- Add a sample web route and a welcome Blade view.
- Provide default configuration files for app, database, and view paths plus an example environment file.
- Include a users table migration and a database seeder stub.

Tests:
- Add PHPUnit configuration with a basic test suite.

Chores:
- Add .env example and .gitignore.